### PR TITLE
Start docker without mapping ports to the localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,7 @@ so you can easily add and edit your conference files.
 To make loading the databases a bit easier on the Docker side I've chosen to
 create two database servers, one for Act itself and the other for the wiki.
 Both can be accessed by the `act` user with the password `act123`. The wiki
-database is named `act_wiki` and the act database is named `act`. The databases
-can be accessed from your local machine by using `psql -U act -h localhost` for
-act itself and `psql -U act -h localhost -p 5433` for the wiki.
+database is named `act_wiki` and the act database is named `act`.
 
 Act itself will do version checking on the database schema, for Docker I've
 chosen to disable this in the act.ini file (for now). You can set the
@@ -127,6 +125,13 @@ xargs -r docker container rm
 docker volume ls | grep act | grep db | awk '{print $NF}' | \
 xargs -r docker volume rm
 ```
+
+### Local access
+
+The databases can be accessed from your local machine if you use an override
+(found in `docker-compose.override.dist`) by using `psql -U act -h localhost`
+for act itself and `psql -U act -h localhost -p 5433` for the wiki.
+Other port numbers can be used, but is left as an exercise for the reader.
 
 ## Plack
 

--- a/docker-compose.override.dist
+++ b/docker-compose.override.dist
@@ -1,11 +1,18 @@
 version: '3.6'
 services:
-    act:
-        command:
-          - "plackup"
-          - "-r"
-          - "app.psgi"
-        environment:
-          - "ACT_DEBUG=Environment Response DBITrace Memory Timer"
+  act:
+    command:
+      - "plackup"
+      - "-r"
+      - "app.psgi"
+    environment:
+      - "ACT_DEBUG=Environment Response DBITrace Memory Timer"
+  act-db:
+    ports:
+      - "5432:5432"
+  act-wiki-db:
+    ports:
+      - "5433:5432"
+
 networks:
     default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,6 @@ services:
       - "./etc/act.ini:/opt/acthome/conf/act.ini"
   act-db:
     image: "postgres:11"
-    ports:
-      - "5432:5432"
     networks:
       - "default"
     environment:
@@ -60,8 +58,9 @@ services:
       - "./db/wiki/template.sql:/docker-entrypoint-initdb.d/00_init_db.sql"
   smtpd:
     image: mailhog/mailhog:v1.0.0
+    expose:
+      - "1025"
     ports:
-      - "1025:1025"
       - "8025:8025"
 
 volumes:


### PR DESCRIPTION
The DB ports and the mailhog ports are now removed and ported to the
docker.override.dist file so that people who want them can still use
them.

Closes: #10