### PR TITLE
Cleanup: Remove unused configuration entries from docs and tests

### DIFF
--- a/eg/conf/act.ini
+++ b/eg/conf/act.ini
@@ -1,6 +1,5 @@
 [general]
 conferences = FIXME
-cookie_name = act
 searchlimit = 20
 dir_photos  = photos
 dir_ttc     = $(home)/var
@@ -14,7 +13,6 @@ user        = foo
 passwd      = foo
 
 [email]
-sendmail    = /usr/sbin/sendmail
 test        = 0
 sender_address = FIXME
 

--- a/lib/Act/Manual/Provider/Configuration.pod
+++ b/lib/Act/Manual/Provider/Configuration.pod
@@ -13,7 +13,6 @@ sections.
 
   [general]
   conferences = tpc-2018-glasgow lpw2019 ....
-  cookie_name = act
   searchlimit = 20
   dir_photos  = photos
   dir_ttc     = $(home)/var
@@ -25,10 +24,6 @@ sections.
 =item C<conferences>
 
 A space-separated list of conferences served by this installation.
-
-=item C<cookie_name>
-
-FIXME: Unused in the current codebase.  To be deleted in a cleanup commit.
 
 =item C<searchlimit>
 
@@ -113,16 +108,10 @@ F<bin/dbbackup>.
 =head2 Section C<email>
 
   [email]
-  sendmail    = /usr/sbin/sendmail
   test        = 0
   sender_address = root@localhost
 
 =over
-
-=item C<sendmail>
-
-Path to the sendmail binary. Happily ignored by the current codebase,
-which uses SMTP.  Might be re-activated soon(ish).
 
 =item C<test>
 

--- a/t/02config.t
+++ b/t/02config.t
@@ -5,7 +5,6 @@ use Test::More qw(no_plan);
 use File::Spec::Functions qw(catfile);
 
 my @simple = qw(
-    general_cookie_name
     general_dir_photos
     general_max_imgsize
     general_searchlimit


### PR DESCRIPTION
Reviewing stuff is a good idea. Here's something from my local bench:

cookie_name has been obsoleted by switching to Plack::Session
email_sendmail wasn't used in the codebase for a long time