### PR TITLE
Fix t/03database.t tests

### DIFF
--- a/lib/Act/Database.pm
+++ b/lib/Act/Database.pm
@@ -1,6 +1,7 @@
 use strict;
 package Act::Database;
-  
+use Try::Tiny;
+
 my @SCHEMA_UPDATES = (
 #1
   "create table schema (
@@ -94,19 +95,20 @@ my @SCHEMA_UPDATES = (
 );
 
 # returns ( current database schema version, required version )
-sub get_versions
-{
+sub get_versions {
     my $dbh = shift;
+
     my $version;
-    eval {
+    try {
         $version = $dbh->selectrow_array('SELECT current_version FROM schema');
-    };
-    if ($@) {
+    }
+    catch {
         $dbh->rollback;
         die "Failed to retrieve the schema version:\n",
             "DB error:   '", $dbh->errstr, "'\n",
-            "eval error: '$@'";
-    }
+            "eval error: '$_'\n";
+    };
+
     defined $version
         or  warn "No database schema version found.\n";
     $version ||= 0;

--- a/t/03database.t
+++ b/t/03database.t
@@ -1,59 +1,43 @@
+use warnings;
 use strict;
-use Act::Config;
-use DBI;
-use Test::More tests => 16;
+use Test::More;
+use Test::Deep;
+use Test::Exception;
 
-my @databases = (
-    [ 'main',
-      $Config->database_dsn,
-      $Config->database_user,
-      $Config->database_passwd,
-    ],
-    [ 'test',
-      $Config->database_test_dsn,
-      $Config->database_test_user,
-      $Config->database_test_passwd,
-    ],
-    [ 'wiki',
-      'dbi:Pg:dbname=' . $Config->wiki_dbname,
-      $Config->wiki_dbuser,
-      $Config->wiki_dbpass,
-    ],
-);
+use Test::MockObject;
 
 require_ok('Act::Database');
-for my $d (@databases) {
-    my ($name, @c) = @$d;
-    my $is_pg = $c[0] =~ /Pg:/ ? 1 : 0;
 
-    my $dbh = DBI->connect(@c,
-                            { AutoCommit => 0,
-                              PrintError => 0,
-                              pg_enable_utf8 => 1,
-                            }
-                          );
-
-    if (not ok $dbh, "$name connect") {
-        SKIP: {
-            skip "connect failed; following tests can't be run", 4
-        }
-        next
-    }
-
-    SKIP: {
-        skip "tests specific to PostgreSQL", 2 unless $is_pg;
-        cmp_ok($dbh->{pg_server_version}, '>=', 80000, "$name server version");
-        cmp_ok($dbh->{pg_lib_version}, '>=', 80000, "$name library version");
-    }
-
-    SKIP: {
-        skip "irrelevent", 1 if $name eq 'wiki';
-        my ($version, $required) = Act::Database::get_versions($dbh);
-        is ($version, $required, "$name schema is up to date");
-    }
-
-    eval { $dbh->disconnect };
-    is $@, "", "$name disconnect";
+{
+    my $warn;
+    local $SIG{__WARN__} = sub { $warn = shift };
+    my $dbh = Test::MockObject->new();
+    $dbh->mock('selectrow_array' => sub { return undef });
+    my @found = Act::Database::get_versions($dbh);
+    cmp_deeply(\@found, [0, 12], "undef returns 0 as a version");
+    is($warn, "No database schema version found.\n", ".. and correct warning found");
 }
+
+{
+    my $dbh = Test::MockObject->new();
+    $dbh->mock('selectrow_array' => sub { return 12 });
+    my @found = Act::Database::get_versions($dbh);
+    cmp_deeply(\@found, [12, 12], "12 returns 12");
+}
+
+{
+    my $dbh = Test::MockObject->new();
+    $dbh->mock('selectrow_array' => sub { die "Failure" });
+    $dbh->mock('rollback' => sub { 1 });
+    $dbh->mock('errstr' => sub { return "we dead" });
+    throws_ok(
+        sub {
+            Act::Database::get_versions($dbh);
+        },
+        qr/Failed to retrieve the schema version/
+    );
+}
+
+done_testing;
 
 __END__

--- a/t/03database.t
+++ b/t/03database.t
@@ -8,13 +8,16 @@ use Test::MockObject;
 
 require_ok('Act::Database');
 
+my $required_version = Act::Database::required_version();
+is($required_version, 12, "12 db upgrades found");
+
 {
     my $warn;
     local $SIG{__WARN__} = sub { $warn = shift };
     my $dbh = Test::MockObject->new();
     $dbh->mock('selectrow_array' => sub { return undef });
     my @found = Act::Database::get_versions($dbh);
-    cmp_deeply(\@found, [0, 12], "undef returns 0 as a version");
+    cmp_deeply(\@found, [0, $required_version], "undef returns 0 as a version");
     is($warn, "No database schema version found.\n", ".. and correct warning found");
 }
 
@@ -22,7 +25,7 @@ require_ok('Act::Database');
     my $dbh = Test::MockObject->new();
     $dbh->mock('selectrow_array' => sub { return 12 });
     my @found = Act::Database::get_versions($dbh);
-    cmp_deeply(\@found, [12, 12], "12 returns 12");
+    cmp_deeply(\@found, [12, $required_version], "12 returns 12");
 }
 
 {


### PR DESCRIPTION
The original code tested wheter the DB connection could be setup and not
if the code actually did what is what supposed to do. Refactor it so it
tests code written in Act::Database.

This change also eliminates the need for Act::Config as the functions
don't need any configuration, just a database handle which
Test::MockObject now provides to us.