### PR TITLE
Fix two issues with password resetting

### DIFF
--- a/lib/Act/Handler/User/ChangePassword.pm
+++ b/lib/Act/Handler/User/ChangePassword.pm
@@ -67,11 +67,13 @@ sub handler
         $fields = $form->{fields};
 
         my ($token, $token_data);
-        if ($Request{user}) { # 
+        my $login;
+        if ($Request{user}) { #
+            $login = $Request{user}->login;
             # compare passwords
             try {
                 Act::Auth::Password->check_password(
-                    $Request{user}->login,$fields->{oldpassword}
+                    $login,$fields->{oldpassword}
                 );
             }
             catch {
@@ -96,10 +98,11 @@ sub handler
                 my $user = Act::User->new(user_id => $token_data)
                     or die "unknown user_id: $token_data\n";
                 Act::TwoStep::remove($token);
+                $login = $user->login;
                 Plack::Session->new($env)->set(login => $user->login);
             }
             # update user
-            Act::Auth::Password->set_password( $Request{user}->login,
+            Act::Auth::Password->set_password( $login,
                                                $fields->{newpassword1} );
 
             # redirect to user's main page

--- a/templates/login
+++ b/templates/login
@@ -47,10 +47,10 @@
 
 </form>
 
+<p>[% loc('Forgot your password?', make_uri('changepwd')) %]</p>
+
 <p>
-  <a href="[% make_uri('changepwd') %]">
-  [% loc('Forgot your password?') %]
-  </a>
+ [% loc('This site uses cookies to authenticate logged in users.', domain) %]
 </p>
 
 </center>


### PR DESCRIPTION
This PR fixes two issues with password resetting in the master branch:

1. The "Forgot your password?" phrase is rendered as a nested anchor due to a recent change in 89cffdf7 which was made in a test environment where I18N didn't work, so it is reverting that commit.
2. After setting a new password in the form the process just dies.