### PR TITLE
Add documentation for email and static files configuration

### DIFF
--- a/lib/Act.pm
+++ b/lib/Act.pm
@@ -1,6 +1,6 @@
 package Act;
 
-our $VERSION = '1.00';
+our $VERSION = '2.00';
 
 1;
 
@@ -94,6 +94,8 @@ Act is sometimes B<erroneously> spelled "ACT".
 
 =head1 HISTORY OF THE SOFTWARE
 
+=head2 Origin and Early Years
+
 In 2003, when the French Perl Mong(u)e(u)rs began organising their
 YAPC::Europe in Paris, they thought about the web site and what they
 wanted to do with it. Starting from Sylvain Lhullier's prototype,
@@ -137,6 +139,49 @@ it will increase visibility and acceptance.
 
 Act currently supports 6 languages: English, French, Italian, Portuguese,
 German and Hungarian. A Hebrew version is in the works.
+
+=head2 A New Decade
+
+...But then, everything fell silent.  Until today, Act is not on CPAN.
+The software worked just fine, so why bother?  Over the years the
+environment evolved.  Apache 1 was superseded with Apache 2, also
+bringing a completely new version of mod_perl.  New alternatives to
+mod_perl were born, making mod_perl look a bit old-fashioned.  Act
+continued to run on Apache 1 and mod_perl 1.
+
+There were several activities to re-vitalize Act.  Details are lost
+(Pull Requests welcome), but some what's still visible is the relics
+are available:
+
+=over 4
+
+=item *
+
+At some point, the Act software was published on GitHub at
+L<https://github.com/book/Act>.  Development continued on SVN, but
+occasionally the changes would be merged to GitHub.
+
+=item *
+
+Rob Hoelz and Graham Knop started to port Act to the new L<PSGI>, but
+activities stopped.
+
+=item *
+
+The L<Act-Voyager repository on
+GitHub|https://github.com/Act-Voyager>, driven by Theo van Hoesel with
+many contributors, saw a lot of activity until about 2013.
+
+=back
+
+=head2 Restarting ... Again
+
+In 2018, some attendees of the German Perl Workshop noticed that the
+Act wiki didn't handle German umlauts correctly.  They found it hard
+to believe that the Perl community would not be able to fix that, dug
+into the code, and started a new activity.  This is still work in
+progress.
+
 
 =head1 COPYRIGHT
 

--- a/lib/Act/Manual/Developer/DeveloperInstall.pod
+++ b/lib/Act/Manual/Developer/DeveloperInstall.pod
@@ -195,14 +195,14 @@ should you ever use PostgreSQL for other purposes.
 
 =head2 Fix the config.ini files
 
-The main config file is expected to be in C<$ACTHOME/conf/act.ini>.  Copy
+The main config file is expected to be in C<$ACT_HOME/conf/act.ini>.  Copy
 the template from the checkout file C<eg/conf/act.ini> to that place
 and fix everything where you find C<FIXME> as a value.  Add the database
 user and password as provided in the previous step (we don't open
 everything up, remember?).
 
 Also fix all FIXMEs in the conference configuration under
-C<$ACTHOME/actdocs/demo/act.ini>.
+C<$ACT_HOME/conferences/demo/actdocs/act.ini>.
 
 =head2 Create the databases and tables
 

--- a/lib/Act/Manual/Developer/Installation.pod
+++ b/lib/Act/Manual/Developer/Installation.pod
@@ -98,7 +98,7 @@ an easy setup is to use a port-based virtual host:
     </VirtualHost>
 
 Create the directory where photos will be uploaded, by default
-F<$ACTHOME/wwwdocs/photos>. Make sure it is readable by all, and
+F<$ACT_HOME/wwwdocs/photos>. Make sure it is readable by all, and
 writable by the user running Apache.
 
 =head2 Setting up the Act databases
@@ -142,7 +142,7 @@ Run wiki-toolkit-setupdb to create the tables in database actwiki.
 
     $ wiki-toolkit-setupdb --type postgres --name actwiki --user act --pass xyzzy
 
-Update F<$ACTHOME/conf/act.ini> (or F<$ACTHOME/conf/local.ini>) with the
+Update F<$ACT_HOME/conf/act.ini> (or F<$ACT_HOME/conf/local.ini>) with the
 database names and credentials.
 
     [database]
@@ -180,14 +180,14 @@ To make sure that your system has all the requirements to run Act,
 and that Act works correctly on it, you can now run Act's test suite.
 This test suite requires Test::More.
 
-    cd $ACTHOME
+    cd $ACT_HOME
     make test
 
 =head1 Adding a new conference
 
 Decide the name of your conference. We'll use act-2004 as an example.
 
-  $ACTHOME/
+  $ACT_HOME/
       actdocs/
         act-2004/
           conf/             # local configuration

--- a/lib/Act/Manual/Developer/UrlsAndFiles.pod
+++ b/lib/Act/Manual/Developer/UrlsAndFiles.pod
@@ -10,7 +10,8 @@ to modernize the Act software.  It is intended to keep the URL
 hierarchy unchanged throughout this process.  The author has, however,
 no idea about the directory structure on the "original" server
 L<https://act.yapc.eu/>: The layout described here is one which fits
-with some of the current PSGI-based implementations.
+with the PSGI-based implementations at
+L<https://github.com/act-testing/Act>.
 
 Throughout this document, we use L<https://act.yapc.eu/> as the base
 URL, though Act software has been used on other servers, too.
@@ -101,9 +102,10 @@ See L<Act::Manual::Developer::Templates> for more information.
 
 =item C<wwwdocs>
 
-These directories under C<wwwdocs> are served directly under the root
-URL, without further processing.  They contain some images, a pretty
-outdated version of jquery, and some stylesheets.
+These directories under C<wwwdocs> are usually served directly under
+the root URL, without further processing.  They contain some images, a
+pretty outdated version of jquery, and some stylesheets.  Providers
+can supply their own directory by configuring C<general_dir_static>.
 
 Conference organisers may use these documents, or commit their own,
 using the appropriate links.
@@ -123,27 +125,31 @@ can't be changed without disruption.
 =head3 Where Act is looking for them
 
 I<Disclaimer:> The author doesn't know the directory structure on any
-productive Act server.  The following description is based on the PSGI
-based implementation, so may be inaccurate.
+productive Act server.  The following description is based on the
+current psgi based implementation, so may be inaccurate on
+C<act.yapc.eu>.
 
 Act has a "home" directory which is passed as a mandatory environment
-variable C<ACTHOME> to the engine.  All paths are calculated from
+variable C<ACT_HOME> to the engine.  All paths are calculated from
 there.  Every conference has its own subdirectory, denoted as
-C<"$conference">.
+C<"$conference">, under a directory configured as
+C<general_dir_conferences>.
 
 =over
 
 =item Configuration files
 
 The configuration files for each conference are expected under
-C<"$ACTHOME/actdocs/$conference/conf/act.ini"> and
-C<"$ACTHOME/actdocs/$conference/conf/local.ini">. Both are evaluated in
-that order.
+C<"$ACT_HOME/conferences/$conference/actdocs/conf/act.ini"> and
+C<"$ACT_HOME/conferences/$conference/actdocsconf/local.ini">.
+Both are evaluated in that order.
 
 If any of the conference config file changes (identified by its
 modification time), then I<all> configuration files, including the
 global configuration, are re-read.  Changes in the global
 configuration file don't trigger the mechanism.
+
+B<Note:> This does not yet work in the PSGI implementation.
 
 =item Template files
 
@@ -153,10 +159,10 @@ top of the list, so there are no "directory-local links".
 
 The list looks like this:
 
-       "$ACTHOME/actdocs/$conference/static",
-       "$ACTHOME/actdocs/$conference/templates",
-       "$ACTHOME/static",
-       "$ACTHOME/templates"
+       "$ACT_HOME/conferences/$conference/actdocs/static",
+       "$ACT_HOME/conferences/$conference/actdocs/templates",
+       "$ACT_HOME/static",
+       "$ACT_HOME/templates"
 
 So, templates provided by the conference organizers take precedence
 over those provided by Act (or added by the people who run the Act
@@ -173,8 +179,8 @@ L<Act::Manual::Organizer::Templates>.
 
 Images, style sheets, javascript libraries and the like for URLs
 containing a conference name are searched for under
-C<"$ACTHOME/$conference/wwwdocs">.  So, an URL
+C<"$ACT_HOME/conferences/$conference/wwwdocs">.  So, an URL
 C<"/$conference/images/logo.png"> is translated into
-C<"$ACTHOME/$conference/wwwdocs/images/logo.png">.
+C<"$ACT_HOME/conferences/$conference/wwwdocs/images/logo.png">.
 
 =back

--- a/lib/Act/Manual/Organizer/Layout.pod
+++ b/lib/Act/Manual/Organizer/Layout.pod
@@ -31,7 +31,7 @@ The F<actdocs> directory is laid out as follows:
 =item * F<conf/>
 
 Configuration files for the conference: they contain information
-sur as begin and end date, room names, tools enabled (online 
+such as begin and end date, room names, tools enabled (online
 payment, pre-registration, etc), languages enabled, etc.
 
 The files are: F<act.ini> and F<local.ini>.

--- a/lib/Act/Manual/Provider/Configuration.pod
+++ b/lib/Act/Manual/Provider/Configuration.pod
@@ -14,6 +14,7 @@ sections.
   [general]
   conferences = tpc-2018-glasgow lpw2019 ....
   searchlimit = 20
+  dir_static  = $($home)/wwwdocs
   dir_photos  = photos
   dir_ttc     = $(home)/var
   max_imgsize = 320x200
@@ -32,11 +33,17 @@ The limit of entries produced on one screen by a user search.
 =item C<dir_photos>
 
 Where user photos are stored.  This directory must exist.  If this is
-a relative path, it is taken relative to the C<ACTHOME> environment
+a relative path, it is taken relative to the C<ACT_HOME> environment
 variable.
 
 This is a global variable because Act's authentication scheme is
 per-installation and not per-conference.
+
+=item C<dir_static>
+
+The directory where static files provided by Act are located.
+Providers must drop files which are to be served under a "root URL",
+e.g. C<robots.txt>, under this directory.
 
 =item C<dir_ttc>
 
@@ -52,7 +59,7 @@ limits.
 =item C<root>
 
 This is the internal value for Act's root directory, usually provided
-externally with the environment variable C<ACTHOME> which gets
+externally with the environment variable C<ACT_HOME> which gets
 translated to the conffiguration variable C<home>.
 
 FIXME: The consequences of having C<root> different from C<home> are
@@ -72,15 +79,7 @@ pretty unclear.  So don't do that.
   test_passwd = dbpass
   pg_dump     = 1
   dump_file   = /tmp/dbdump
-
-  # Required for waterkip's fork preparing dockerization.  They are in
-  # the code, but missing from everywhere else.  If they aren't
-  # defined, there is a warning per request for each variable (A
-  # feature of AppConfig).  Note that defining 'localhost' as the host
-  # name will change the database driver's protocol from "local" to
-  # "host".  By using a "defined but false" value here we keep the
-  # "local" (UNIX sockets) protocol for a database on the same host.
-  version_check = 0
+  version_check = 1
   host = 0
 
 =over
@@ -103,6 +102,16 @@ The command and the target file for the database backup (PostgreSQL
 only).  A false value for C<pg_dump> prohibits backups with
 F<bin/dbbackup>.
 
+=item C<version_check>
+
+If true, Act will check at compile time whether the schema version
+of database and code match.
+
+=item C<host>
+
+The host where the database is running.  Set to C<0> if Act is using a
+C<local> connection to a database server running on the same host.
+
 =back
 
 =head2 Section C<email>
@@ -110,6 +119,8 @@ F<bin/dbbackup>.
   [email]
   test        = 0
   sender_address = root@localhost
+  hostname = localhost
+  port = 25
 
 =over
 
@@ -124,6 +135,15 @@ This is used as the "From" address for outgoing mails.  Usually this
 setting is overridden by organizers for their own conference, but
 sometimes Act might want to send mails without a conference context.
 
+=item C<hostname> and C<port>
+
+Hostname and port of the SMTP server which is used for sending mail.
+Both settings are mandatory.
+
+For docker deployments and for testing, the settings can be overridden
+by the environment variables C<SMTP_HOST> and C<SMTP_PORT>,
+respectively.
+
 =back
 
 
@@ -132,14 +152,13 @@ sometimes Act might want to send mails without a conference context.
   dbname      = actwiki
   dbuser      = dbuser
   dbpass      = dbpass
-
-  # Required for waterkip's fork preparing dockerization,
-  # see above for details.
-  dbhost = 0
+  dbhost      = 0
 
 As above, these are the settings for the wiki database.
 Note that there's no DSN parameter: The Act wiki assumes
-a PostGreSQL database.
+a PostGreSQL database.  For C<dbhost>, a value of C<0>
+is used for a C<local> connection to a database server
+running on the same host.
 
 =head2 Section C<payment>
 

--- a/lib/Act/Manual/Provider/Performance.pod
+++ b/lib/Act/Manual/Provider/Performance.pod
@@ -1,95 +1,11 @@
 =head1 Act performance hints
 
-The following describes steps you can take to get the best performance
-out of your Act installation, in a production environment. Full
-explanations of the techniques used are outside of the scope of this
-document, so we only provide introductory comments.
+This section needs to be rewritten: We do not have experience how the
+PSGI based implementations perform.
 
-=head2 pre-loading modules at Apache startup and persistent database connections
+The PSGI implementation comes as a persistent Perl interpreter out of
+the box, so the "old" mod_perl mechanism of preloading modules is no
+longer required.
 
-Insert the following configuration directive in httpd.conf:
-
-PerlModule $ACTHOME/conf/startup.pl
-
-This improves performance (modules are pre-loaded at server startup)
-and memory usage (modules are loaded in the parent server and thanks
-to copy-on-write their code is shared, at least for a while.)
-
-startup.pl also uses Apache::DBI to enable persistent database connections,
-obviating the need to connect to the database for each request.
-
-=head2 Dual Apache setup
-
-mod_perl-enabled servers tend to have a large memory footprint, so you don't
-want too many of them. Server instances tend to spend most of their time
-serving responses to slow clients ("spoon-feeding" clients.) 
-
-This setup uses 2 instances of Apache: the front-end, or "light" server
-serves static content (images, CSS files), and reverse-proxies dynamic
-content to the back-end, or "heavy" server.
-
-The light server uses mod_proxy but no mod_perl, therefore its memory
-footprint is much lower. The heavy server sends its output to the light
-server very fast, so it isn't tied up spoon-feeding the clients. With such
-a setup it is possible to serve a high request rate with relatively few
-back-end processes.
-
-In the example below we choose to run both instances on the same machine.
-The heavy server runs on localhost on a high port, while the light server
-runs on our public IP on port 80. This also provides protection against
-direct access to the heavy server.
-
-Here's the relevant configuration snippet for the heavy server:
-
-  BindAddress     127.0.0.1
-  KeepAlive       Off
-
-You want to keep KeepAlive Off so as not to keep server processes tied
-up doing nothing.
-
-  MinSpareServers     5
-  MaxSpareServers     5
-  StartServers        10
-  MaxClients          20
-  MaxRequestsPerChild 500
-
-These numbers are only an indication, tailor them to your requirements
-and amount of available RAM. We keep MaxClients low because that's
-the whole point of this setup, and MaxRequestsPerChild low to improve
-sharing.
-
-  PerlRequire /home/act/conf/startup.pl
-  Listen 9000
-  <VirtualHost 127.0.0.1:9000>
-    ServerName    www.example.com
-    DocumentRoot  /home/act/wwwdocs
-    Port          80
-    Include       /home/act/conf/httpd.conf
-  </VirtualHost>
-
-In this context, the Listen directive specifies which port this server
-listens to, and the Port directive specifies which port to use when issuing a
-redirect.
-
-In the light server, enable mod_proxy and mod_rewrite. We'll use them
-to reverse-proxy requests for dynamic content to the back-end. Again,
-adjust the numbers to your requirements and hardware.
-
-  MinSpareServers 10
-  MaxSpareServers 15
-  StartServers    100
-  MaxClients      200
-
-  <VirtualHost *:80>
-    ServerName    www.example.com
-    DocumentRoot  /home/act/wwwdocs
-
-    RewriteEngine       on
-    RewriteOptions      'inherit'
-    RewriteRule         \.(css|gif|ico|jpg|pdf|png|txt)$    -                        [L]
-    RewriteRule         ^/(.*)$                             http://127.0.0.1:8000/$1 [P,L]
-    ProxyPassReverse    /  http://www.example.com/
-  </VirtualHost>
-
-=cut
-
+A quite popular setup is to run Nginx as a frontend and L<starman> as
+the PSGI backend for Act.

--- a/lib/Act/Manual/Provider/Templates.pod
+++ b/lib/Act/Manual/Provider/Templates.pod
@@ -13,14 +13,14 @@ To do so, perform the following steps:
 
 =over 4
 
-=item Create a directory C<static> under $ACTHOME.
+=item Create a directory C<static> under $ACT_HOME.
 
 =item In that directory, write your content to a file F<error404>.
 
 =back
 
 So, the full path to your custom template is
-F<$ACTHOME/static/error404>.  This template is processed with Act's
+F<$ACT_HOME/static/error404>.  This template is processed with Act's
 Template Toolkit, therefore you can use the templates in the
-F<$ACTHOME/templates> directory, but it has I<no access> to
+F<$ACT_HOME/templates> directory, but it has I<no access> to
 configuration data nor to templates customized for a conference.


### PR DESCRIPTION
Document config variables email_host, email_port (and their ENV counterparts) and general_dir_static, which needed to be set to get the demo server back on track.  Also, start retiring ACTHOME in favor of ACT_HOME, because having both of them around is silly.