### PR TITLE
Cleanup ports and expose in docker-compose.yml and docker-compose.ove…

### DIFF
--- a/docker-compose.override.dist
+++ b/docker-compose.override.dist
@@ -13,6 +13,9 @@ services:
   act-wiki-db:
     ports:
       - "5433:5432"
+  smtpd:
+    ports:
+      - "8025:8025"
 
 networks:
     default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,8 @@ services:
     image: mailhog/mailhog:v1.0.0
     expose:
       - "1025"
+    ports:
+      - "8025:8025"
 
 volumes:
   act_db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
     image: "postgres:11"
     networks:
       - "default"
+    expose:
+      - "5432"
     environment:
       - "POSTGRES_USER=act"
       - "POSTGRES_PASSWORD=act123"
@@ -43,10 +45,10 @@ services:
       - "./db/act/template.sql:/docker-entrypoint-initdb.d/00_init_db.sql"
   act-wiki-db:
     image: "postgres:11"
-    ports:
-      - "5433:5432"
     networks:
       - "default"
+    expose:
+      - "5432"
     environment:
       - "POSTGRES_USER=act"
       - "POSTGRES_PASSWORD=act123"
@@ -60,8 +62,6 @@ services:
     image: mailhog/mailhog:v1.0.0
     expose:
       - "1025"
-    ports:
-      - "8025:8025"
 
 volumes:
   act_db:


### PR DESCRIPTION
…rwrite.dist

* Removed port usage in docker-compose.yml.
  Only tcp/5000 is exposed to the host by default.
* Added port statements to docker-compose.overwrite.dist which should be applied
  if you want to have full access to postgres and mailhog
* Added expose statements to match the Dockerfile definition of postgres:11

FYI:
I did this to move potential port clashes if you have a postgres running on tcp/5432 or tcp/5433. This is most likely the case if you already work/devel for Act and are planning to switch to the dockerized setup.

The current setup was just taking care for clashes in tcp/5432 but not on tcp/5433.

https://docs.docker.com/compose/compose-file/#expose
https://docs.docker.com/compose/compose-file/#ports
